### PR TITLE
Support Python 2.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
 python:
+  - "2.7"
   - "3.6"
 
 addons:
@@ -20,8 +21,8 @@ before_install:
 
 install:
   - futhark-c --library test.fut
-  - python3 setup.py install
+  - python setup.py install
   - build_futhark_ffi test
 
 script:
-  - python3 test.py
+  - python test.py

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 from setuptools import setup
 from os import path
+import io
 
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with io.open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(

--- a/test.py
+++ b/test.py
@@ -28,11 +28,14 @@ class TestFFI(unittest.TestCase):
 
     def test_2d(self):
         data = np.arange(9).reshape(3,3)
+
         res = self.fut.test5(data)
         pyres = self.fut.from_futhark(res)
         assert_array_equal(pyres, data*2)
-        with self.assertRaises(ValueError):
-            self.fut.test5(data.T)
+
+        res = self.fut.test5(data.T)
+        pyres = self.fut.from_futhark(res)
+        assert_array_equal(pyres, (data*2).T)
 
     def test_opaque(self):
         res = self.fut.test6(10)
@@ -62,10 +65,12 @@ class TestCompat(unittest.TestCase):
 
     def test_2d(self):
         data = np.arange(9).reshape(3,3)
+
         res = self.fut.test5(data).get()
         assert_array_equal(res, data*2)
-        with self.assertRaises(ValueError):
-            self.fut.test5(data.T)
+
+        res = self.fut.test5(data.T).get()
+        assert_array_equal(res, (data*2).T)
 
     def test_opaque(self):
         res = self.fut.test6(10)


### PR DESCRIPTION
Note that this also changes the behaviour of to_futhark to perform a
copy if the passed-in array does not have 'C' order.  This is mostly
because Python 2.7's CFFI does not itself raise an error in this case
(Python 3 does), and it was easier (and more practically useful) to do
the copy than to insert our own check.