### PR TITLE
Fix futhark compilation failure

### DIFF
--- a/test.fut
+++ b/test.fut
@@ -14,7 +14,8 @@ entry test5 (a:[][]u64) : [][]u64 =
   map (map (*2)) a
 
 entry test6 (a:i8) : [](i8, i8) =
-  map (\x -> (x, -x)) <| i8.iota a
+  let iot = i8.iota a
+  in map (\x -> (x, -x)) <| iot
 
 entry test7 (a: [](i8, i8)) : ([]i8, []i8) =
   unzip a


### PR DESCRIPTION
With the latest version of the compiler test.fut (version 0.17.0) longer compiles. I have fixed the code so it compiles with latest version of the futhark compiler.

Before code change...

```
Error at test.fut:17:3-5:
Causality check: size "ret₇" needed for type of "map":
  (f: i8 -> (i8, i8)) -> (as: [ret₇]i8) -> *[ret₇](i8, i8)
But "ret₇" is computed at 17:26-34.
Hint: Bind the expression producing "ret₇" with 'let' beforehand.

If you find this error message confusing, uninformative, or wrong, please open an issue at
https://github.com/diku-dk/futhark/issues.
```

After the code change...

```
Warning at test.fut:16:1-18:31:
  Entry point return type

    [](i8, i8)

  will have an opaque type, so the result will likely not be usable.

Warning at test.fut:20:1-21:9:
  Entry point parameter

    ((a: [impl₀](i8, i8)): [impl₀](i8, i8))

  will have an opaque type, so the entry point will likely not be callable.
```

Still has warnings. But no longer fails to compile.