### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "2.7"
   - "3.6"
 
+dist: trusty
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Sorry I know that you aren't actively working on this. But since the time it was built before my last build, things have changed with travis. Travis used to default to the `trusty` distro but now changed to default to the `xenial` distro. This creates problems with OpenCL, as it seems xenial doesn't have it by default. I have changed it so now we default to trusty (the way it used to be when build passed on travis). 

I feel partly responsible as my last change broke the build even if it was really travis changing some things up. Should be fixed now. 