### PR TITLE
Strip `extern "C"` declarations

### DIFF
--- a/futhark_ffi/build.py
+++ b/futhark_ffi/build.py
@@ -1,8 +1,9 @@
+import re
 import sys
 from cffi import FFI
 
-def strip_includes(lines):
-    return '\n'.join(line for line in lines if not line.startswith('#'))
+def strip_includes(header):
+    return re.sub('^(#ifdef __cplusplus\n.*\n#endif|#.*)\n', '', header, flags=re.M)
 
 def build(name):
     ffibuilder = FFI()
@@ -21,7 +22,7 @@ def build(name):
     with open(name+'.h') as header:
         cdef = 'typedef void* cl_command_queue;'
         cdef += '\ntypedef void* cl_mem;'
-        cdef += strip_includes(header)
+        cdef += strip_includes(header.read())
         cdef += "\nvoid free(void *ptr);"
         ffibuilder.cdef(cdef)
 


### PR DESCRIPTION
These were added to header files in Futhark 0.18.6. Without removing them, a `cffi.CDefError: cannot parse "extern "C" {"` error will be thrown.