### PR TITLE
Travis CI: Upgrade libffi6 --> libffi7 for Ubuntu focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     packages:
     - wget
     - libgmp-dev
-    - libffi6
+    - libffi7
     - libc6:i386
     - ocl-icd-libopencl1
 


### PR DESCRIPTION
https://packages.ubuntu.com/source/focal/libffi

https://travis-ci.org/github/pepijndevos/futhark-pycffi/pull_requests